### PR TITLE
neuron update to kalliope 0.6

### DIFF
--- a/dna.yml
+++ b/dna.yml
@@ -4,8 +4,7 @@
   author: "https://github.com/royto"
 
   kalliope_supported_version:
-    - 0.4
-    - 0.5
+    - 0.6
 
   tags:
     - "rss feed"

--- a/install.yml
+++ b/install.yml
@@ -4,9 +4,8 @@
   gather_facts: no
   connection: local
 
-  tasks:
-    - name: "Install pip dependencies"
-      pip:
-        name: feedparser
-        version: 5.2.1
-
+- name: "Install pip dependencies"
+    pip:
+      name: "feedparser"
+      version: 5.2.1
+      executable: pip3


### PR DESCRIPTION
switching the library installation to python 3 and the dna.yml file for kalliope 0.6